### PR TITLE
Split off heavier packages, make `espaloma-base`

### DIFF
--- a/recipe/build_base.sh
+++ b/recipe/build_base.sh
@@ -1,0 +1,1 @@
+${PYTHON} -m pip install . --no-deps -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,39 +10,54 @@ source:
   sha256: 8f3f2481d949aa7f59759540815d4e7de1d6ff168efeb3ce818ea2b155d2428f
 
 build:
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
   number: 1
 
-requirements:
-  host:
-    - pip
-    - python =3.11
-  run:
-    - matplotlib-base
-    - numpy
-    - openff-forcefields
-    - openff-toolkit >=0.12.0
-    - openff-units
-    - openmm
-    - openmmforcefields >=0.11.2
-    - pydantic <2
-    - python >=3.9
-    - pytorch
-    - qcportal >=0.15.0,<0.50.0a0
-    - scipy
-    - smirnoff99Frosst
-    - tqdm
-  run_constrained:
-    - dgl =1.1.2
+outputs:
+  - name: espaloma-base
+    script: build_base.sh
+    build:
+      noarch: python
+    requirements:
+      host:
+        - pip
+        - python =3.11
+      run:
+        - python >=3.9
+        - numpy
+        - openff-forcefields
+        - openff-toolkit >=0.12.0
+        - openff-units
+        - openmm
+        - openmmforcefields >=0.11.2
+        - pydantic <2
+        - pytorch
+        - qcportal =0.15
+        - scipy
+        - tqdm
+    test:
+      imports:
+        - espaloma
 
-test:
-  imports:
-    - espaloma
-  commands:
-    - pip check
-  requires:
-    - pip
+  - name: espaloma
+    build:
+      noarch: python
+    requirements:
+      host:
+        - python >=3.9
+      run:
+        - python >=3.9
+        - matplotlib-base
+        - dgl =1.1.2
+        - {{ pin_subpackage('espaloma-base', exact=True) }}
+    test:
+      imports:
+        - espaloma
+      commands:
+        - pip check
+        - pytest --pyargs espaloma
+      requires:
+        - pip
+        - pytest
 
 about:
   home: https://github.com/choderalab/espaloma

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,14 +12,13 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
-  number: 0
+  number: 1
 
 requirements:
   host:
     - pip
     - python >=3.9
   run:
-    - dgl =1.1.2
     - matplotlib-base
     - numpy
     - openff-forcefields
@@ -34,6 +33,8 @@ requirements:
     - scipy
     - smirnoff99Frosst
     - tqdm
+  run_constrained
+    - dgl =1.1.2
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ build:
 requirements:
   host:
     - pip
-    - python >=3.9
+    - python =3.11
   run:
     - matplotlib-base
     - numpy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ requirements:
     - scipy
     - smirnoff99Frosst
     - tqdm
-  run_constrained
+  run_constrained:
     - dgl =1.1.2
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,8 +35,12 @@ outputs:
         - scipy
         - tqdm
     test:
+      files:
+        - test_readme.py
       imports:
         - espaloma
+      commands:
+        - python test_readme.py
 
   - name: espaloma
     build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,10 +41,8 @@ test:
     - espaloma
   commands:
     - pip check
-    - pytest --pyargs espaloma
   requires:
     - pip
-    - pytest
 
 about:
   home: https://github.com/choderalab/espaloma

--- a/recipe/test_readme.py
+++ b/recipe/test_readme.py
@@ -5,9 +5,9 @@ from openff.toolkit import Molecule
 
 
 
-graph = esp.Graph(Molecule.from_smiles("CN1C=NC2=C1C(=O)N(C(=O)N2C)C"))
+graph = espaloma.Graph(Molecule.from_smiles("CN1C=NC2=C1C(=O)N(C(=O)N2C)C"))
 
-model = esp.get_model("latest")
+model = espaloma.get_model("latest")
 
 model(graph.heterograph)
 

--- a/recipe/test_readme.py
+++ b/recipe/test_readme.py
@@ -1,0 +1,14 @@
+import torch
+import espaloma
+
+from openff.toolkit import Molecule
+
+
+
+graph = esp.Graph(Molecule.from_smiles("CN1C=NC2=C1C(=O)N(C(=O)N2C)C"))
+
+model = esp.get_model("latest")
+
+model(graph.heterograph)
+
+espaloma.graphs.deploy.openmm_system_from_graph(graph)


### PR DESCRIPTION
#11 

This would enable installation on `osx-arm64` if it works

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
